### PR TITLE
Add support for ARM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,9 @@
 			<version>23.1.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.sejda.imageio</groupId>
+			<groupId>com.github.gotson</groupId>
 			<artifactId>webp-imageio</artifactId>
-			<version>0.1.6</version>
+			<version>0.2.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Update the dependency for the WEBP image conversion library to a forked version that supports ARM architectures. This change addresses the issue of WEBP image conversion failures on Linux aarch64 and other ARM platforms.

Fixes #74