### PR TITLE
Add ConfigTool for unified site configuration management

### DIFF
--- a/src/main/java/org/sentrysoftware/maven/skin/ConfigTool.java
+++ b/src/main/java/org/sentrysoftware/maven/skin/ConfigTool.java
@@ -20,10 +20,10 @@ package org.sentrysoftware.maven.skin;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
+import java.util.WeakHashMap;
 
 import org.apache.velocity.tools.config.DefaultKey;
 import org.apache.velocity.tools.generic.SafeConfig;
@@ -69,9 +69,10 @@ public class ConfigTool extends SafeConfig {
 
 	/**
 	 * Cache for parsed head content to avoid re-parsing the same content multiple times.
-	 * Uses weak references to allow garbage collection when memory is needed.
+	 * Uses a WeakHashMap so entries can be garbage collected when headContent strings are no longer referenced.
+	 * Wrapped with synchronizedMap for thread safety since ConfigTool is in application scope.
 	 */
-	private final Map<Integer, WeakReference<Map<String, String>>> metaCache = new HashMap<>();
+	private final Map<String, Map<String, String>> metaCache = Collections.synchronizedMap(new WeakHashMap<>());
 
 	/**
 	 * Creates a new instance of ConfigTool.
@@ -203,36 +204,10 @@ public class ConfigTool extends SafeConfig {
 			return null;
 		}
 
-		// Check cache first
-		int cacheKey = Objects.hash(headContent);
-		Map<String, String> metaMap = getCachedMetaMap(cacheKey);
-
-		if (metaMap == null) {
-			// Parse and cache
-			metaMap = parseMetaTags(headContent);
-			metaCache.put(cacheKey, new WeakReference<>(metaMap));
-		}
+		// Get from cache or parse and cache
+		Map<String, String> metaMap = metaCache.computeIfAbsent(headContent, this::parseMetaTags);
 
 		return metaMap.get(key);
-	}
-
-	/**
-	 * Get cached meta map from weak reference.
-	 *
-	 * @param cacheKey The cache key
-	 * @return The cached map or null if not in cache or garbage collected
-	 */
-	private Map<String, String> getCachedMetaMap(final int cacheKey) {
-		WeakReference<Map<String, String>> ref = metaCache.get(cacheKey);
-		if (ref != null) {
-			Map<String, String> map = ref.get();
-			if (map != null) {
-				return map;
-			}
-			// Reference was cleared, remove stale entry
-			metaCache.remove(cacheKey);
-		}
-		return null;
 	}
 
 	/**
@@ -321,5 +296,15 @@ public class ConfigTool extends SafeConfig {
 		default:
 			return defaultValue;
 		}
+	}
+
+	/**
+	 * Returns the current size of the meta cache.
+	 * This method is package-private for testing purposes only.
+	 *
+	 * @return The number of entries in the meta cache
+	 */
+	int getCacheSize() {
+		return metaCache.size();
 	}
 }

--- a/src/main/java/org/sentrysoftware/maven/skin/ConfigTool.java
+++ b/src/main/java/org/sentrysoftware/maven/skin/ConfigTool.java
@@ -20,10 +20,15 @@ package org.sentrysoftware.maven.skin;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.velocity.tools.config.DefaultKey;
 import org.apache.velocity.tools.generic.SafeConfig;
@@ -68,11 +73,25 @@ import org.jsoup.select.Elements;
 public class ConfigTool extends SafeConfig {
 
 	/**
+	 * Logger for this class.
+	 */
+	private static final Logger LOGGER = Logger.getLogger(ConfigTool.class.getName());
+
+	/**
 	 * Cache for parsed head content to avoid re-parsing the same content multiple times.
 	 * Uses a WeakHashMap so entries can be garbage collected when headContent strings are no longer referenced.
 	 * Wrapped with synchronizedMap for thread safety since ConfigTool is in application scope.
+	 * Note: Failed parses are not cached to allow retry on subsequent calls.
 	 */
 	private final Map<String, Map<String, String>> metaCache = Collections.synchronizedMap(new WeakHashMap<>());
+
+	/**
+	 * Cache for resolved getCustomValue Method per siteModel class.
+	 * Uses Optional to distinguish between "not yet looked up" (absent from map) and
+	 * "looked up but not found" (Optional.empty() in map).
+	 * ConcurrentHashMap for thread safety.
+	 */
+	private final Map<Class<?>, Optional<Method>> methodCache = new ConcurrentHashMap<>();
 
 	/**
 	 * Creates a new instance of ConfigTool.
@@ -204,19 +223,28 @@ public class ConfigTool extends SafeConfig {
 			return null;
 		}
 
-		// Get from cache or parse and cache
-		Map<String, String> metaMap = metaCache.computeIfAbsent(headContent, this::parseMetaTags);
+		// Check cache first
+		Map<String, String> metaMap = metaCache.get(headContent);
+		if (metaMap != null) {
+			return metaMap.get(key);
+		}
 
-		return metaMap.get(key);
+		// Parse and cache only on success
+		metaMap = parseMetaTags(headContent);
+		if (metaMap != null) {
+			metaCache.put(headContent, metaMap);
+			return metaMap.get(key);
+		}
+
+		return null;
 	}
 
 	/**
 	 * Parse all meta tags from head content into a map.
 	 *
 	 * @param headContent The HTML head content
-	 * @return Map of meta name to content value
+	 * @return Map of meta name to content value, or null if parsing fails
 	 */
-	@SuppressWarnings("PMD.EmptyCatchBlock")
 	private Map<String, String> parseMetaTags(final String headContent) {
 
 		Map<String, String> metaMap = new HashMap<>();
@@ -233,7 +261,12 @@ public class ConfigTool extends SafeConfig {
 				}
 			}
 		} catch (Exception e) {
-			// Return empty map on parsing error
+			LOGGER
+					.log(
+							Level.WARNING,
+							"Failed to parse head content for meta tags, will retry on next access",
+							e);
+			return null;
 		}
 
 		return metaMap;
@@ -246,23 +279,54 @@ public class ConfigTool extends SafeConfig {
 	 * @param key The custom value key
 	 * @return The custom value, or null if not found or error
 	 */
-	@SuppressWarnings("PMD.EmptyCatchBlock")
 	private String getSiteCustomValue(final Object siteModel, final String key) {
 
 		if (siteModel == null) {
 			return null;
 		}
 
+		Class<?> siteModelClass = siteModel.getClass();
+
+		// Get cached method lookup result, or perform lookup
+		Optional<Method> cachedMethod = methodCache.computeIfAbsent(siteModelClass, clazz -> {
+			try {
+				// Try to find getCustomValue(String) method
+				// This works with both Maven Site Plugin 3.x (DecorationModel) and 4.x (SiteModel)
+				return Optional.of(clazz.getMethod("getCustomValue", String.class));
+			} catch (NoSuchMethodException e) {
+				LOGGER
+						.log(
+								Level.FINE,
+								String
+										.format(
+												"Site model class %s does not have getCustomValue(String) method, "
+														+ "configuration will fall back to defaults",
+												clazz.getName()));
+				return Optional.empty();
+			}
+		});
+
+		// If method was not found, return null
+		if (cachedMethod.isEmpty()) {
+			return null;
+		}
+
+		// Invoke the cached method
 		try {
-			// Try to call getCustomValue(String) using reflection
-			// This works with both Maven Site Plugin 3.x (DecorationModel) and 4.x (SiteModel)
-			java.lang.reflect.Method method = siteModel.getClass().getMethod("getCustomValue", String.class);
-			Object result = method.invoke(siteModel, key);
+			Object result = cachedMethod.get().invoke(siteModel, key);
 			if (result instanceof String) {
 				return (String) result;
 			}
 		} catch (ReflectiveOperationException e) {
-			// Method not found or invocation failed - return null
+			LOGGER
+					.log(
+							Level.WARNING,
+							String
+									.format(
+											"Failed to invoke getCustomValue('%s') on site model of type %s",
+											key,
+											siteModelClass.getName()),
+							e);
 		}
 
 		return null;

--- a/src/main/java/org/sentrysoftware/maven/skin/ConfigTool.java
+++ b/src/main/java/org/sentrysoftware/maven/skin/ConfigTool.java
@@ -1,0 +1,325 @@
+package org.sentrysoftware.maven.skin;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Sentry Maven Skin Tools
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2017 - 2026 Sentry Software
+ * ჻჻჻჻჻჻
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.velocity.tools.config.DefaultKey;
+import org.apache.velocity.tools.generic.SafeConfig;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * An Apache Velocity tool that provides unified configuration management for Maven sites,
+ * merging site-wide configuration from site.xml with per-page overrides from Markdown front matter.
+ * <p>
+ * Configuration precedence (highest to lowest):
+ * <ol>
+ * <li>Front matter (converted to {@code <meta>} tags in headContent)</li>
+ * <li>Site-wide configuration ({@code <custom>} element in site.xml)</li>
+ * <li>Default value provided by the caller</li>
+ * </ol>
+ * <p>
+ * Front matter in Markdown files:
+ *
+ * <pre>{@code
+ * ---
+ * interpolation: none
+ * showToc: false
+ * tocMaxDepth: 3
+ * ---
+ * }</pre>
+ *
+ * is converted by Doxia to {@code <meta>} tags:
+ *
+ * <pre>{@code
+ * <meta name="interpolation" content="none"/>
+ * <meta name="showToc" content="false"/>
+ * <meta name="tocMaxDepth" content="3"/>
+ * }</pre>
+ *
+ * @author Bertrand Martin
+ * @since 1.6
+ */
+@DefaultKey("configTool")
+public class ConfigTool extends SafeConfig {
+
+	/**
+	 * Cache for parsed head content to avoid re-parsing the same content multiple times.
+	 * Uses weak references to allow garbage collection when memory is needed.
+	 */
+	private final Map<Integer, WeakReference<Map<String, String>>> metaCache = new HashMap<>();
+
+	/**
+	 * Creates a new instance of ConfigTool.
+	 */
+	public ConfigTool() {
+		/* Do nothing */
+	}
+
+	/**
+	 * Get a configuration value with front matter overriding site.xml settings.
+	 * <p>
+	 * Usage in Velocity:
+	 *
+	 * <pre>{@code
+	 * #set($interpolation = $configTool.getValue($site, $headContent, "interpolation", "maven"))
+	 * }</pre>
+	 *
+	 * @param siteModel The site decoration model ($site or $decoration) - can be null
+	 * @param headContent The HTML head content string containing meta tags ($headContent) - can be null
+	 * @param key The configuration key (e.g., "interpolation", "showToc")
+	 * @param defaultValue The default value if not found in either source
+	 * @return The configuration value (front matter &gt; site.xml &gt; default)
+	 * @since 1.6
+	 */
+	public String getValue(
+			final Object siteModel,
+			final String headContent,
+			final String key,
+			final String defaultValue) {
+
+		// Check front matter (highest priority)
+		String frontMatterValue = getMetaValue(headContent, key);
+		if (frontMatterValue != null) {
+			return frontMatterValue;
+		}
+
+		// Check site.xml custom values
+		String siteValue = getSiteCustomValue(siteModel, key);
+		if (siteValue != null) {
+			return siteValue;
+		}
+
+		// Return default
+		return defaultValue;
+	}
+
+	/**
+	 * Get a boolean configuration value with proper string-to-boolean conversion.
+	 * <p>
+	 * Recognizes "true", "yes", "1" as true (case-insensitive).
+	 * Recognizes "false", "no", "0" as false (case-insensitive).
+	 * Any other value returns the default.
+	 * </p>
+	 * <p>
+	 * Usage in Velocity:
+	 *
+	 * <pre>{@code
+	 * #set($showToc = $configTool.getBooleanValue($site, $headContent, "showToc", true))
+	 * }</pre>
+	 *
+	 * @param siteModel The site decoration model ($site or $decoration) - can be null
+	 * @param headContent The HTML head content string containing meta tags ($headContent) - can be null
+	 * @param key The configuration key (e.g., "showToc", "checkImages")
+	 * @param defaultValue The default value if not found or invalid
+	 * @return The boolean configuration value (front matter &gt; site.xml &gt; default)
+	 * @since 1.6
+	 */
+	public boolean getBooleanValue(
+			final Object siteModel,
+			final String headContent,
+			final String key,
+			final boolean defaultValue) {
+
+		String value = getValue(siteModel, headContent, key, null);
+		if (value == null) {
+			return defaultValue;
+		}
+
+		return parseBoolean(value, defaultValue);
+	}
+
+	/**
+	 * Get an integer configuration value.
+	 * <p>
+	 * If the value cannot be parsed as an integer, returns the default value.
+	 * </p>
+	 * <p>
+	 * Usage in Velocity:
+	 *
+	 * <pre>{@code
+	 * #set($tocMaxDepth = $configTool.getIntValue($site, $headContent, "tocMaxDepth", 3))
+	 * }</pre>
+	 *
+	 * @param siteModel The site decoration model ($site or $decoration) - can be null
+	 * @param headContent The HTML head content string containing meta tags ($headContent) - can be null
+	 * @param key The configuration key (e.g., "tocMaxDepth", "maxImageWidth")
+	 * @param defaultValue The default value if not found or invalid
+	 * @return The integer configuration value (front matter &gt; site.xml &gt; default)
+	 * @since 1.6
+	 */
+	public int getIntValue(
+			final Object siteModel,
+			final String headContent,
+			final String key,
+			final int defaultValue) {
+
+		String value = getValue(siteModel, headContent, key, null);
+		if (value == null) {
+			return defaultValue;
+		}
+
+		try {
+			return Integer.parseInt(value.trim());
+		} catch (NumberFormatException e) {
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Extract a meta tag value from the head content HTML.
+	 *
+	 * @param headContent The HTML head content containing meta tags
+	 * @param key The meta tag name to look for
+	 * @return The content attribute value, or null if not found
+	 */
+	private String getMetaValue(final String headContent, final String key) {
+
+		if (headContent == null || headContent.isEmpty()) {
+			return null;
+		}
+
+		// Check cache first
+		int cacheKey = Objects.hash(headContent);
+		Map<String, String> metaMap = getCachedMetaMap(cacheKey);
+
+		if (metaMap == null) {
+			// Parse and cache
+			metaMap = parseMetaTags(headContent);
+			metaCache.put(cacheKey, new WeakReference<>(metaMap));
+		}
+
+		return metaMap.get(key);
+	}
+
+	/**
+	 * Get cached meta map from weak reference.
+	 *
+	 * @param cacheKey The cache key
+	 * @return The cached map or null if not in cache or garbage collected
+	 */
+	private Map<String, String> getCachedMetaMap(final int cacheKey) {
+		WeakReference<Map<String, String>> ref = metaCache.get(cacheKey);
+		if (ref != null) {
+			Map<String, String> map = ref.get();
+			if (map != null) {
+				return map;
+			}
+			// Reference was cleared, remove stale entry
+			metaCache.remove(cacheKey);
+		}
+		return null;
+	}
+
+	/**
+	 * Parse all meta tags from head content into a map.
+	 *
+	 * @param headContent The HTML head content
+	 * @return Map of meta name to content value
+	 */
+	@SuppressWarnings("PMD.EmptyCatchBlock")
+	private Map<String, String> parseMetaTags(final String headContent) {
+
+		Map<String, String> metaMap = new HashMap<>();
+
+		try {
+			Document doc = Jsoup.parseBodyFragment(headContent);
+			Elements metaTags = doc.select("meta[name][content]");
+
+			for (Element meta : metaTags) {
+				String name = meta.attr("name");
+				String content = meta.attr("content");
+				if (!name.isEmpty() && !content.isEmpty()) {
+					metaMap.put(name, content);
+				}
+			}
+		} catch (Exception e) {
+			// Return empty map on parsing error
+		}
+
+		return metaMap;
+	}
+
+	/**
+	 * Get a custom value from the site decoration model.
+	 *
+	 * @param siteModel The site model object (DecorationModel or SiteModel)
+	 * @param key The custom value key
+	 * @return The custom value, or null if not found or error
+	 */
+	@SuppressWarnings("PMD.EmptyCatchBlock")
+	private String getSiteCustomValue(final Object siteModel, final String key) {
+
+		if (siteModel == null) {
+			return null;
+		}
+
+		try {
+			// Try to call getCustomValue(String) using reflection
+			// This works with both Maven Site Plugin 3.x (DecorationModel) and 4.x (SiteModel)
+			java.lang.reflect.Method method = siteModel.getClass().getMethod("getCustomValue", String.class);
+			Object result = method.invoke(siteModel, key);
+			if (result instanceof String) {
+				return (String) result;
+			}
+		} catch (ReflectiveOperationException e) {
+			// Method not found or invocation failed - return null
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parse a string value as boolean with support for common truthy/falsy values.
+	 *
+	 * @param value The string value to parse
+	 * @param defaultValue The default value if parsing fails
+	 * @return true if value is "true", "yes", or "1" (case-insensitive), false if "false", "no", or "0",
+	 *         otherwise defaultValue
+	 */
+	private boolean parseBoolean(final String value, final boolean defaultValue) {
+
+		if (value == null) {
+			return defaultValue;
+		}
+
+		String normalized = value.trim().toLowerCase();
+
+		switch (normalized) {
+		case "true":
+		case "yes":
+		case "1":
+			return true;
+		case "false":
+		case "no":
+		case "0":
+			return false;
+		default:
+			return defaultValue;
+		}
+	}
+}

--- a/src/main/resources/tools.xml
+++ b/src/main/resources/tools.xml
@@ -23,6 +23,7 @@
 	The tools.xml file is included in the classpath and Velocity finds it. -->
 <tools>
 	<toolbox scope="application">
+		<tool key="configTool" class="org.sentrysoftware.maven.skin.ConfigTool" />
 		<tool key="htmlTool" class="org.sentrysoftware.maven.skin.HtmlTool" />
 		<tool key="indexTool" class="org.sentrysoftware.maven.skin.IndexTool" />
 		<tool key="imageTool" class="org.sentrysoftware.maven.skin.ImageTool" />

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -50,7 +50,7 @@ This allows the Maven Skin and [Velocity-processed pages in a Maven Site](https:
 The above tools are designed to be used only in the Velocity template of a [Maven Site Skin](https://maven.apache.org/plugins/maven-site-plugin/examples/creatingskins.html) as in the example below:
 
 #[[
-```html
+```velocity
 #set($bodyElement = $htmlTool.parseContent($bodyContent))
 #set($bodyElement = $imageTool.explicitImageSize($bodyElement, "img", ${project.reporting.outputDirectory}, $currentFileName))
 <html>
@@ -66,7 +66,7 @@ $bodyElement.html()
 The `ConfigTool` provides unified configuration management, merging site-wide settings from `site.xml` with per-page overrides from Markdown front matter:
 
 #[[
-```html
+```velocity
 <!-- In your Velocity skin template -->
 #set($interpolation = $configTool.getValue($site, $headContent, "interpolation", "maven"))
 #set($showToc = $configTool.getBooleanValue($site, $headContent, "showToc", true))
@@ -124,7 +124,7 @@ Additionally, we allow the use of these standard Velocity tools in the Velocity-
 Example:
 
 #[[
-```sh
+```velocity
 #set( $repoList = $json.fetch("https://api.github.com/orgs/sentrysoftware/repos") )
 #if( $repoList && $repoList.size() > 0 )
 | Repository | Description |

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -41,6 +41,7 @@ This allows the Maven Skin and [Velocity-processed pages in a Maven Site](https:
 
 | Tool | Description | Javadoc |
 |---|---|---|
+| `#[[$configTool]]#` | To manage site configuration with front matter overrides | [ConfigTool](apidocs/org/sentrysoftware/maven/skin/ConfigTool.html) |
 | `#[[$htmlTool]]#` | To manipulate HTML documents or fragments | [HtmlTool](apidocs/org/sentrysoftware/maven/skin/HtmlTool.html) |
 | `#[[$imageTool]]#` | To manipulate images | [ImageTool](apidocs/org/sentrysoftware/maven/skin/ImageTool.html) |
 | `#[[$indexTool]]#` | To create search indexes | [IndexTool](apidocs/org/sentrysoftware/maven/skin/IndexTool.html) |
@@ -57,6 +58,58 @@ The above tools are designed to be used only in the Velocity template of a [Mave
 $bodyElement.html()
 </body>
 </html>
+```
+]]#
+
+## ConfigTool Usage
+
+The `ConfigTool` provides unified configuration management, merging site-wide settings from `site.xml` with per-page overrides from Markdown front matter:
+
+#[[
+```html
+<!-- In your Velocity skin template -->
+#set($interpolation = $configTool.getValue($site, $headContent, "interpolation", "maven"))
+#set($showToc = $configTool.getBooleanValue($site, $headContent, "showToc", true))
+#set($tocMaxDepth = $configTool.getIntValue($site, $headContent, "tocMaxDepth", 3))
+
+#if($showToc)
+  <!-- Render table of contents with max depth $tocMaxDepth -->
+#end
+```
+]]#
+
+Configuration precedence (highest to lowest):
+1. **Front matter** in Markdown files (converted to `<meta>` tags by Doxia)
+2. **Site-wide configuration** in `site.xml` under `<custom>` element
+3. **Default value** specified in the method call
+
+Example front matter in a Markdown page:
+
+#[[
+```markdown
+---
+interpolation: none
+showToc: false
+tocMaxDepth: 2
+---
+
+# My Page Title
+
+Content goes here...
+```
+]]#
+
+Example site-wide configuration in `site.xml`:
+
+#[[
+```xml
+<project>
+  <custom>
+    <interpolation>maven</interpolation>
+    <showToc>true</showToc>
+    <tocMaxDepth>3</tocMaxDepth>
+  </custom>
+</project>
 ```
 ]]#
 

--- a/src/test/java/org/sentrysoftware/maven/skin/ConfigToolTest.java
+++ b/src/test/java/org/sentrysoftware/maven/skin/ConfigToolTest.java
@@ -1,0 +1,354 @@
+package org.sentrysoftware.maven.skin;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Sentry Maven Skin Tools
+ * ჻჻჻჻჻჻
+ * Copyright 2017 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConfigToolTest {
+
+	private ConfigTool configTool;
+
+	/**
+	 * Mock site model for testing
+	 */
+	private static class MockSiteModel {
+		private final java.util.Map<String, String> customValues = new java.util.HashMap<>();
+
+		public void setCustomValue(final String key, final String value) {
+			customValues.put(key, value);
+		}
+
+		public String getCustomValue(final String key) {
+			return customValues.get(key);
+		}
+	}
+
+	@BeforeEach
+	void setUp() {
+		configTool = new ConfigTool();
+	}
+
+	@Test
+	void testGetValueWithFrontMatter() {
+		String headContent = "<meta name=\"interpolation\" content=\"none\"/>";
+		MockSiteModel site = new MockSiteModel();
+		site.setCustomValue("interpolation", "maven");
+
+		// Front matter should override site value
+		String result = configTool.getValue(site, headContent, "interpolation", "default");
+		assertEquals("none", result);
+	}
+
+	@Test
+	void testGetValueFromSiteOnly() {
+		MockSiteModel site = new MockSiteModel();
+		site.setCustomValue("interpolation", "maven");
+
+		// Should get value from site.xml
+		String result = configTool.getValue(site, null, "interpolation", "default");
+		assertEquals("maven", result);
+	}
+
+	@Test
+	void testGetValueWithDefault() {
+		MockSiteModel site = new MockSiteModel();
+
+		// Should return default value
+		String result = configTool.getValue(site, null, "nonExistent", "default");
+		assertEquals("default", result);
+	}
+
+	@Test
+	void testGetValueWithNullSiteAndHeadContent() {
+		// Should return default value
+		String result = configTool.getValue(null, null, "test", "default");
+		assertEquals("default", result);
+	}
+
+	@Test
+	void testGetValueWithEmptyHeadContent() {
+		MockSiteModel site = new MockSiteModel();
+		site.setCustomValue("test", "siteValue");
+
+		// Empty head content should fall back to site value
+		String result = configTool.getValue(site, "", "test", "default");
+		assertEquals("siteValue", result);
+	}
+
+	@Test
+	void testGetValueWithMultipleMetaTags() {
+		String headContent = "<meta name=\"interpolation\" content=\"none\"/>" +
+				"<meta name=\"showToc\" content=\"false\"/>" +
+				"<meta name=\"tocMaxDepth\" content=\"3\"/>";
+
+		String result1 = configTool.getValue(null, headContent, "interpolation", "default");
+		assertEquals("none", result1);
+
+		String result2 = configTool.getValue(null, headContent, "showToc", "default");
+		assertEquals("false", result2);
+
+		String result3 = configTool.getValue(null, headContent, "tocMaxDepth", "default");
+		assertEquals("3", result3);
+	}
+
+	@Test
+	void testGetBooleanValueTrue() {
+		String headContent = "<meta name=\"showToc\" content=\"true\"/>";
+
+		assertTrue(configTool.getBooleanValue(null, headContent, "showToc", false));
+	}
+
+	@Test
+	void testGetBooleanValueFalse() {
+		String headContent = "<meta name=\"showToc\" content=\"false\"/>";
+
+		assertFalse(configTool.getBooleanValue(null, headContent, "showToc", true));
+	}
+
+	@Test
+	void testGetBooleanValueYes() {
+		String headContent = "<meta name=\"checkImages\" content=\"yes\"/>";
+
+		assertTrue(configTool.getBooleanValue(null, headContent, "checkImages", false));
+	}
+
+	@Test
+	void testGetBooleanValueNo() {
+		String headContent = "<meta name=\"checkImages\" content=\"no\"/>";
+
+		assertFalse(configTool.getBooleanValue(null, headContent, "checkImages", true));
+	}
+
+	@Test
+	void testGetBooleanValueNumeric() {
+		String headContent1 = "<meta name=\"enabled\" content=\"1\"/>";
+		assertTrue(configTool.getBooleanValue(null, headContent1, "enabled", false));
+
+		String headContent0 = "<meta name=\"disabled\" content=\"0\"/>";
+		assertFalse(configTool.getBooleanValue(null, headContent0, "disabled", true));
+	}
+
+	@Test
+	void testGetBooleanValueCaseInsensitive() {
+		String headContent = "<meta name=\"test\" content=\"TRUE\"/>";
+
+		assertTrue(configTool.getBooleanValue(null, headContent, "test", false));
+	}
+
+	@Test
+	void testGetBooleanValueInvalid() {
+		String headContent = "<meta name=\"test\" content=\"invalid\"/>";
+
+		// Should return default for invalid boolean value
+		assertTrue(configTool.getBooleanValue(null, headContent, "test", true));
+		assertFalse(configTool.getBooleanValue(null, headContent, "test", false));
+	}
+
+	@Test
+	void testGetBooleanValueFromSite() {
+		MockSiteModel site = new MockSiteModel();
+		site.setCustomValue("showToc", "true");
+
+		assertTrue(configTool.getBooleanValue(site, null, "showToc", false));
+	}
+
+	@Test
+	void testGetBooleanValueWithDefault() {
+		// Should return default when not found
+		assertTrue(configTool.getBooleanValue(null, null, "nonExistent", true));
+		assertFalse(configTool.getBooleanValue(null, null, "nonExistent", false));
+	}
+
+	@Test
+	void testGetIntValue() {
+		String headContent = "<meta name=\"tocMaxDepth\" content=\"5\"/>";
+
+		assertEquals(5, configTool.getIntValue(null, headContent, "tocMaxDepth", 3));
+	}
+
+	@Test
+	void testGetIntValueFromSite() {
+		MockSiteModel site = new MockSiteModel();
+		site.setCustomValue("maxWidth", "1024");
+
+		assertEquals(1024, configTool.getIntValue(site, null, "maxWidth", 800));
+	}
+
+	@Test
+	void testGetIntValueInvalid() {
+		String headContent = "<meta name=\"test\" content=\"notAnInteger\"/>";
+
+		// Should return default for invalid integer value
+		assertEquals(42, configTool.getIntValue(null, headContent, "test", 42));
+	}
+
+	@Test
+	void testGetIntValueWithDefault() {
+		// Should return default when not found
+		assertEquals(100, configTool.getIntValue(null, null, "nonExistent", 100));
+	}
+
+	@Test
+	void testGetIntValueWithWhitespace() {
+		String headContent = "<meta name=\"test\" content=\" 123 \"/>";
+
+		assertEquals(123, configTool.getIntValue(null, headContent, "test", 0));
+	}
+
+	@Test
+	void testPrecedenceOrder() {
+		// Test that front matter takes precedence over site.xml
+		String headContent = "<meta name=\"interpolation\" content=\"frontMatter\"/>";
+		MockSiteModel site = new MockSiteModel();
+		site.setCustomValue("interpolation", "siteValue");
+
+		String result = configTool.getValue(site, headContent, "interpolation", "default");
+		assertEquals("frontMatter", result);
+	}
+
+	@Test
+	void testSitePrecedenceOverDefault() {
+		// Test that site.xml takes precedence over default
+		MockSiteModel site = new MockSiteModel();
+		site.setCustomValue("test", "siteValue");
+
+		String result = configTool.getValue(site, null, "test", "default");
+		assertEquals("siteValue", result);
+	}
+
+	@Test
+	void testMetaTagWithoutContent() {
+		String headContent = "<meta name=\"test\"/>";
+
+		// Meta tag without content should be ignored
+		String result = configTool.getValue(null, headContent, "test", "default");
+		assertEquals("default", result);
+	}
+
+	@Test
+	void testMetaTagWithoutName() {
+		String headContent = "<meta content=\"value\"/>";
+
+		// Meta tag without name should be ignored
+		String result = configTool.getValue(null, headContent, "test", "default");
+		assertEquals("default", result);
+	}
+
+	@Test
+	void testComplexHeadContent() {
+		String headContent = "<title>Test Page</title>" +
+				"<meta charset=\"UTF-8\"/>" +
+				"<meta name=\"interpolation\" content=\"none\"/>" +
+				"<meta name=\"description\" content=\"Test page description\"/>" +
+				"<link rel=\"stylesheet\" href=\"style.css\"/>" +
+				"<meta name=\"showToc\" content=\"true\"/>";
+
+		String result1 = configTool.getValue(null, headContent, "interpolation", "default");
+		assertEquals("none", result1);
+
+		boolean result2 = configTool.getBooleanValue(null, headContent, "showToc", false);
+		assertTrue(result2);
+	}
+
+	@Test
+	void testCaching() {
+		// Test that parsing result is cached
+		String headContent = "<meta name=\"test\" content=\"value\"/>";
+
+		// First call should parse
+		String result1 = configTool.getValue(null, headContent, "test", "default");
+		assertEquals("value", result1);
+
+		// Second call with same headContent should use cache
+		String result2 = configTool.getValue(null, headContent, "test", "default");
+		assertEquals("value", result2);
+
+		// Call with different key but same headContent should also use cache
+		String result3 = configTool.getValue(null, headContent, "other", "default");
+		assertEquals("default", result3);
+	}
+
+	@Test
+	void testNullSiteModelHandling() {
+		String headContent = "<meta name=\"test\" content=\"value\"/>";
+
+		// Should handle null site model gracefully
+		String result = configTool.getValue(null, headContent, "test", "default");
+		assertEquals("value", result);
+	}
+
+	@Test
+	void testMalformedHtml() {
+		String headContent = "<meta name=\"test\" content=\"value\">" + // Missing closing tag
+				"<div><meta name=\"other\" content=\"otherValue\"></div>";
+
+		// Should still parse despite malformed HTML (Jsoup is lenient)
+		String result = configTool.getValue(null, headContent, "test", "default");
+		assertEquals("value", result);
+	}
+
+	@Test
+	void testEmptyMetaContent() {
+		String headContent = "<meta name=\"test\" content=\"\"/>";
+
+		// Empty content should be ignored
+		String result = configTool.getValue(null, headContent, "test", "default");
+		assertEquals("default", result);
+	}
+
+	@Test
+	void testSiteModelWithNullCustomValue() {
+		MockSiteModel site = new MockSiteModel();
+		// Don't set any custom value
+
+		String result = configTool.getValue(site, null, "test", "default");
+		assertEquals("default", result);
+	}
+
+	@Test
+	void testIntegrationScenario() {
+		// Simulate a real-world scenario
+		MockSiteModel site = new MockSiteModel();
+		site.setCustomValue("interpolation", "maven");
+		site.setCustomValue("showToc", "true");
+		site.setCustomValue("tocMaxDepth", "3");
+
+		String headContent = "<meta name=\"interpolation\" content=\"none\"/>" +
+				"<meta name=\"showToc\" content=\"false\"/>";
+
+		// interpolation overridden by front matter
+		assertEquals("none", configTool.getValue(site, headContent, "interpolation", "default"));
+
+		// showToc overridden by front matter
+		assertFalse(configTool.getBooleanValue(site, headContent, "showToc", true));
+
+		// tocMaxDepth from site.xml (not in front matter)
+		assertEquals(3, configTool.getIntValue(site, headContent, "tocMaxDepth", 5));
+
+		// nonExistent uses default
+		assertEquals("default", configTool.getValue(site, headContent, "nonExistent", "default"));
+	}
+}

--- a/src/test/java/org/sentrysoftware/maven/skin/ConfigToolTest.java
+++ b/src/test/java/org/sentrysoftware/maven/skin/ConfigToolTest.java
@@ -275,20 +275,32 @@ class ConfigToolTest {
 
 	@Test
 	void testCaching() {
-		// Test that parsing result is cached
-		String headContent = "<meta name=\"test\" content=\"value\"/>";
+		// Test that parsing result is cached and reused
+		String headContent1 = "<meta name=\"test\" content=\"value\"/>";
+		String headContent2 = "<meta name=\"other\" content=\"otherValue\"/>";
 
-		// First call should parse
-		String result1 = configTool.getValue(null, headContent, "test", "default");
+		// Cache should be empty initially
+		assertEquals(0, configTool.getCacheSize());
+
+		// First call should parse and cache
+		String result1 = configTool.getValue(null, headContent1, "test", "default");
 		assertEquals("value", result1);
+		assertEquals(1, configTool.getCacheSize());
 
-		// Second call with same headContent should use cache
-		String result2 = configTool.getValue(null, headContent, "test", "default");
+		// Second call with same headContent should use cache (size unchanged)
+		String result2 = configTool.getValue(null, headContent1, "test", "default");
 		assertEquals("value", result2);
+		assertEquals(1, configTool.getCacheSize());
 
 		// Call with different key but same headContent should also use cache
-		String result3 = configTool.getValue(null, headContent, "other", "default");
+		String result3 = configTool.getValue(null, headContent1, "other", "default");
 		assertEquals("default", result3);
+		assertEquals(1, configTool.getCacheSize());
+
+		// Call with different headContent should add a new cache entry
+		String result4 = configTool.getValue(null, headContent2, "other", "default");
+		assertEquals("otherValue", result4);
+		assertEquals(2, configTool.getCacheSize());
 	}
 
 	@Test


### PR DESCRIPTION
# Add ConfigTool for Unified Site Configuration Management

## Overview

This PR introduces a new `ConfigTool` that provides unified configuration management for Maven sites, merging site-wide settings from `site.xml` with per-page overrides from Markdown front matter.

## Problem

Previously, handling configuration with front matter overrides required verbose manual code in Velocity templates for each variable:

```velocity
#set($interpolation = $site.getCustomValue("interpolation", "maven"))
#set($tempHeadElement = $htmlTool.parseContent($headContent))
#if($tempHeadElement)
    #set($pageInterpolation = $htmlTool.getAttr($tempHeadElement, "meta[name=interpolation]", "content"))
    #if($pageInterpolation && !$pageInterpolation.isEmpty())
        #set($interpolation = $pageInterpolation.get(0))
    #end
#end
```

This pattern needed to be repeated for every configuration variable, making the code verbose and error-prone.

## Solution

The new `ConfigTool` provides a clean, type-safe API:

```velocity
#set($interpolation = $configTool.getValue($site, $headContent, "interpolation", "maven"))
#set($showToc = $configTool.getBooleanValue($site, $headContent, "showToc", true))
#set($tocMaxDepth = $configTool.getIntValue($site, $headContent, "tocMaxDepth", 3))
```

## Features

### Configuration Precedence
1. **Front matter** (per-page) - highest priority
2. **Site-wide configuration** (`site.xml`)
3. **Default value** - specified in the method call

### API Methods
- **`getValue()`** - Get string configuration values
- **`getBooleanValue()`** - Get boolean values with intelligent parsing
  - Recognizes `"true"`, `"yes"`, `"1"` as true (case-insensitive)
  - Recognizes `"false"`, `"no"`, `"0"` as false (case-insensitive)
- **`getIntValue()`** - Get integer values with proper error handling

### Technical Highlights
- ✅ Weak reference caching to avoid re-parsing headContent multiple times
- ✅ Reflection-based site model access (compatible with Maven Site Plugin 3.x and 4.x)
- ✅ Null-safe handling of all inputs
- ✅ Comprehensive error handling with sensible defaults

## Testing

- **31 new unit tests** covering all functionality
- Tests for precedence order, type conversion, null safety, caching, and edge cases
- **All 108 tests pass** (including existing tests)

## Code Quality

- ✅ **Checkstyle**: 0 violations
- ✅ **PMD**: 0 violations
- ✅ **SpotBugs**: 0 bugs
- ✅ **Javadoc**: Complete and valid
- ✅ **Code formatting**: Compliant
- ✅ **License headers**: Present

## Documentation

Updated `src/site/markdown/index.md` with:
- Usage examples
- Configuration precedence explanation  
- Front matter and site.xml examples

## Files Changed

- ✨ **New**: `src/main/java/org/sentrysoftware/maven/skin/ConfigTool.java`
- ✨ **New**: `src/test/java/org/sentrysoftware/maven/skin/ConfigToolTest.java`
- 📝 **Modified**: `src/main/resources/tools.xml` (registered `$configTool`)
- 📝 **Modified**: `src/site/markdown/index.md` (added documentation)

## Usage Example

### Markdown Front Matter
```markdown
---
interpolation: none
showToc: false
tocMaxDepth: 2
---

# My Page

Content here...
```

### Site-wide Configuration (site.xml)
```xml
<project>
  <custom>
    <interpolation>maven</interpolation>
    <showToc>true</showToc>
    <tocMaxDepth>3</tocMaxDepth>
  </custom>
</project>
```

### Velocity Template Usage
```velocity
#set($interpolation = $configTool.getValue($site, $headContent, "interpolation", "maven"))
#set($showToc = $configTool.getBooleanValue($site, $headContent, "showToc", true))
#set($tocMaxDepth = $configTool.getIntValue($site, $headContent, "tocMaxDepth", 3))

#if($showToc)
  <!-- Render table of contents with max depth $tocMaxDepth -->
#end
```

## Closes

Fixes #103