### PR TITLE
Upgrade GraalVM dependencies for JDK 22 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 Velocity Tools used by the [Sentry Maven Skin](https://sentrysoftware.github.io/maven-skin).
 
+## Requirements
+
+Maven must run on JDK 17 or later to use Maven Skin Tools.
+
 ## Documentation
 
 Visit the [Maven Skin Tools Documentation Site](https://sentrysoftware.github.io/maven-skin-tools).

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,10 @@
 	</developers>
 
 	<properties>
-		<!-- Java 11 -->
-		<maven.compiler.release>11</maven.compiler.release>
+		<!-- Java 17 -->
+		<maven.compiler.release>17</maven.compiler.release>
+
+		<graalvm.version>25.0.3</graalvm.version>
 
 		<!-- Reproducible Build -->
 		<!-- See https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
@@ -87,14 +89,15 @@
 			<version>1.22.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.graalvm.js</groupId>
-			<artifactId>js</artifactId>
-			<version>23.0.11</version>
+			<groupId>org.graalvm.polyglot</groupId>
+			<artifactId>polyglot</artifactId>
+			<version>${graalvm.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.graalvm.js</groupId>
-			<artifactId>js-scriptengine</artifactId>
-			<version>25.0.2</version>
+			<groupId>org.graalvm.polyglot</groupId>
+			<artifactId>js</artifactId>
+			<version>${graalvm.version}</version>
+			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>com.github.gotson</groupId>
@@ -107,6 +110,44 @@
 
 		<!-- Actual build plugins -->
 		<plugins>
+
+			<!-- Bootstrap the documentation site with the released skin tools while replacing
+			the legacy GraalJS dependencies on JDK 22 and later. -->
+			<plugin>
+				<artifactId>maven-site-plugin</artifactId>
+				<dependencies>
+					<dependency>
+						<groupId>org.sentrysoftware.maven</groupId>
+						<artifactId>maven-skin-tools</artifactId>
+						<version>1.3.00</version>
+						<exclusions>
+							<exclusion>
+								<groupId>org.graalvm.js</groupId>
+								<artifactId>js</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>org.graalvm.js</groupId>
+								<artifactId>js-scriptengine</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>org.graalvm.truffle</groupId>
+								<artifactId>truffle-api</artifactId>
+							</exclusion>
+						</exclusions>
+					</dependency>
+					<dependency>
+						<groupId>org.graalvm.polyglot</groupId>
+						<artifactId>polyglot</artifactId>
+						<version>${graalvm.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.graalvm.polyglot</groupId>
+						<artifactId>js</artifactId>
+						<version>${graalvm.version}</version>
+						<type>pom</type>
+					</dependency>
+				</dependencies>
+			</plugin>
 
 			<!--formatter -->
 			<plugin>
@@ -203,5 +244,15 @@
 
 		</plugins>
 	</build>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.9.8.3</version>
+			</plugin>
+		</plugins>
+	</reporting>
 
 </project>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -22,6 +22,10 @@
 This artifact contains a collection of Velocity tools that are used by the
 [Sentry Maven Skin](https://sentrysoftware/github.io/maven-skin).
 
+## Requirements
+
+Maven must run on JDK 17 or later to use Maven Skin Tools.
+
 This artifact must be loaded as a dependency by the Maven Site plugin, as below:
 
 ```xml


### PR DESCRIPTION
## Summary
- Upgrade the project to Java 17 and GraalVM 25.0.3
- Replace legacy GraalJS dependencies with Polyglot artifacts
- Override Maven Site plugin dependencies to support JDK 22 and later
- Document the JDK 17 requirement
- Add SpotBugs reporting configuration

## Testing
- Not run (not requested)