### PR TITLE
Improve AI-ready Markdown export for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Maven must run on JDK 17 or later to use Maven Skin Tools.
 
 Visit the [Maven Skin Tools Documentation Site](https://sentrysoftware.github.io/maven-skin-tools).
 
+## AI-ready Markdown export
+
+`HtmlToMarkdownConverter` produces machine-readable Markdown for `.html.md` documentation exports. It linearizes
+interactive tabs, preserves callouts as blockquotes, keeps table pipes and technical quotes intact, aligns table of
+contents links with Markdown heading anchors, and omits print-only link footnotes.
+
 ## Contributing
 
 A few rules:

--- a/src/main/java/org/sentrysoftware/maven/skin/HtmlToMarkdownConverter.java
+++ b/src/main/java/org/sentrysoftware/maven/skin/HtmlToMarkdownConverter.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -42,6 +44,9 @@ import org.jsoup.nodes.TextNode;
  * </p>
  */
 public final class HtmlToMarkdownConverter {
+	private static final Pattern TECHNICAL_QUOTED_VALUE = Pattern
+			.compile(
+					"([\\p{Alnum}_.:-]+=)([\\u2018\\u2019\\u201c\\u201d])([^\\u2018\\u2019\\u201c\\u201d]*)([\\u2018\\u2019\\u201c\\u201d])");
 
 	/**
 	 * Private constructor to prevent instantiation.
@@ -457,7 +462,7 @@ public final class HtmlToMarkdownConverter {
 		ensureBlankLine(result);
 
 		Element calloutContent = element.clone();
-		Element title = calloutContent.selectFirst(".callout-title");
+		Element title = directCalloutTitle(calloutContent);
 		String label = title == null ? "" : markdownVisibleText(title);
 		if (title != null) {
 			title.remove();
@@ -470,6 +475,18 @@ public final class HtmlToMarkdownConverter {
 		quoteContent.append("**").append(label).append("**\n\n");
 		processElement(calloutContent, quoteContent, state);
 		appendBlockquote(quoteContent.toString(), result);
+	}
+
+	/**
+	 * Finds the title that belongs directly to a callout, excluding nested callout titles.
+	 */
+	private static Element directCalloutTitle(final Element callout) {
+		for (Element child : callout.children()) {
+			if (child.hasClass("callout-title")) {
+				return child;
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -556,9 +573,7 @@ public final class HtmlToMarkdownConverter {
 			StringBuilder cellContent = new StringBuilder();
 			processElement(cell, cellContent, state);
 			String content = cellContent.toString().trim().replaceAll("\\s+", " ");
-			if (isTechnicalTableCell(cell, content)) {
-				content = normalizeTypographicQuotes(content);
-			}
+			content = normalizeTechnicalAssignments(content);
 			content = escapeTablePipes(content);
 			result.append(" ").append(content).append(" |");
 			cellCount++;
@@ -629,12 +644,20 @@ public final class HtmlToMarkdownConverter {
 	}
 
 	/**
-	 * Checks whether a table cell contains code markup or syntax that must retain ASCII quotes.
+	 * Normalizes typographic quotes only within compact technical assignments such as
+	 * {@code key=“value”}, preserving typographic quotes in surrounding prose.
 	 */
-	private static boolean isTechnicalTableCell(final Element cell, final String content) {
-		return cell.selectFirst("code, pre, kbd, samp") != null
-				|| content.indexOf('\\') >= 0
-				|| content.matches(".*[\\p{Alnum}_.:-]+=[\\u2018\\u2019\\u201c\\u201d].*");
+	private static String normalizeTechnicalAssignments(final String content) {
+		Matcher matcher = TECHNICAL_QUOTED_VALUE.matcher(content);
+		StringBuffer normalized = new StringBuffer(content.length());
+		while (matcher.find()) {
+			char openingQuote = matcher.group(2).charAt(0);
+			String quote = openingQuote == '\u201c' || openingQuote == '\u201d' ? "\"" : "'";
+			String replacement = matcher.group(1) + quote + matcher.group(3) + quote;
+			matcher.appendReplacement(normalized, Matcher.quoteReplacement(replacement));
+		}
+		matcher.appendTail(normalized);
+		return normalized.toString();
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/maven/skin/HtmlToMarkdownConverter.java
+++ b/src/main/java/org/sentrysoftware/maven/skin/HtmlToMarkdownConverter.java
@@ -20,6 +20,13 @@ package org.sentrysoftware.maven.skin;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -74,7 +81,7 @@ public final class HtmlToMarkdownConverter {
 		}
 
 		StringBuilder result = new StringBuilder();
-		processElement(element, result, new ConversionState());
+		processElement(element, result, new ConversionState(element));
 		return result.toString().trim();
 	}
 
@@ -121,6 +128,9 @@ public final class HtmlToMarkdownConverter {
 		if (result.length() > 0 && result.charAt(result.length() - 1) == '\n' && text.startsWith(" ")) {
 			text = text.stripLeading();
 		}
+		if (result.length() > 0 && result.charAt(result.length() - 1) == ' ' && text.startsWith(" ")) {
+			text = text.stripLeading();
+		}
 
 		result.append(text);
 	}
@@ -137,6 +147,15 @@ public final class HtmlToMarkdownConverter {
 			final StringBuilder result,
 			final ConversionState state) {
 		String tagName = element.tagName().toLowerCase();
+
+		if (element.hasClass("visible-print-inline") || element.hasClass("sentry-print-tab-heading")) {
+			return;
+		}
+
+		if (element.hasClass("callout")) {
+			processCallout(element, result, state);
+			return;
+		}
 
 		switch (tagName) {
 		case "h1":
@@ -169,21 +188,17 @@ public final class HtmlToMarkdownConverter {
 			break;
 		case "strong":
 		case "b":
-			result.append("**");
-			processElement(element, result, state);
-			result.append("**");
+			processEmphasis(element, result, state, "**");
 			break;
 		case "em":
 		case "i":
-			result.append("*");
-			processElement(element, result, state);
-			result.append("*");
+			processEmphasis(element, result, state, "*");
 			break;
 		case "code":
 			if (!state.isInPreformatted()) {
-				result.append("`");
-				processElement(element, result, state);
-				result.append("`");
+				StringBuilder code = new StringBuilder();
+				processElement(element, code, state);
+				result.append("`").append(normalizeTypographicQuotes(code.toString())).append("`");
 			} else {
 				processElement(element, result, state);
 			}
@@ -213,6 +228,9 @@ public final class HtmlToMarkdownConverter {
 		case "table":
 			processTable(element, result, state);
 			break;
+		case "uib-tab-heading":
+			processTabHeading(element, result);
+			break;
 		case "div":
 		case "section":
 		case "article":
@@ -241,6 +259,25 @@ public final class HtmlToMarkdownConverter {
 	}
 
 	/**
+	 * Processes bold or italic content without emitting empty Markdown delimiters.
+	 */
+	private static void processEmphasis(
+			final Element element,
+			final StringBuilder result,
+			final ConversionState state,
+			final String delimiter) {
+		StringBuilder content = new StringBuilder();
+		processElement(element, content, state);
+		if (content.toString().isBlank()) {
+			if (content.length() > 0 && (result.length() == 0 || result.charAt(result.length() - 1) != ' ')) {
+				result.append(' ');
+			}
+		} else {
+			result.append(delimiter).append(content).append(delimiter);
+		}
+	}
+
+	/**
 	 * Processes a heading element.
 	 */
 	private static void processHeading(
@@ -250,7 +287,22 @@ public final class HtmlToMarkdownConverter {
 			final int level) {
 		ensureBlankLine(result);
 		result.append("#".repeat(level)).append(" ");
-		processElement(element, result, state);
+
+		Element selfLink = null;
+		if (element.childrenSize() == 1 && element.ownText().isBlank()) {
+			Element onlyChild = element.child(0);
+			if ("a".equals(onlyChild.tagName())
+					&& !element.id().isEmpty()
+					&& onlyChild.attr("href").equals("#" + element.id())) {
+				selfLink = onlyChild;
+			}
+		}
+
+		if (selfLink == null) {
+			processElement(element, result, state);
+		} else {
+			processElement(selfLink, result, state);
+		}
 		result.append("\n\n");
 	}
 
@@ -290,9 +342,9 @@ public final class HtmlToMarkdownConverter {
 		result.append("```").append(language).append("\n");
 
 		if (codeElement != null) {
-			result.append(codeElement.wholeText());
+			result.append(normalizeTypographicQuotes(codeElement.wholeText()));
 		} else {
-			result.append(element.wholeText());
+			result.append(normalizeTypographicQuotes(element.wholeText()));
 		}
 
 		// Ensure the code block ends with a newline
@@ -306,8 +358,8 @@ public final class HtmlToMarkdownConverter {
 	 * Processes a link element.
 	 */
 	private static void processLink(final Element element, final StringBuilder result, final ConversionState state) {
-		String href = element.attr("href");
-		String text = element.text();
+		String href = state.resolveHref(element.attr("href"));
+		String text = markdownVisibleText(element);
 
 		if (href.isEmpty()) {
 			// No href, just output the text
@@ -392,13 +444,58 @@ public final class HtmlToMarkdownConverter {
 
 		StringBuilder quoteContent = new StringBuilder();
 		processElement(element, quoteContent, state);
+		appendBlockquote(quoteContent.toString(), result);
+	}
 
-		// Prefix each line with >
-		String[] lines = quoteContent.toString().trim().split("\n");
+	/**
+	 * Processes a Sentry Maven Skin callout as a Markdown blockquote with a bold title.
+	 */
+	private static void processCallout(
+			final Element element,
+			final StringBuilder result,
+			final ConversionState state) {
+		ensureBlankLine(result);
+
+		Element calloutContent = element.clone();
+		Element title = calloutContent.selectFirst(".callout-title");
+		String label = title == null ? "" : markdownVisibleText(title);
+		if (title != null) {
+			title.remove();
+		}
+		if (label.isBlank()) {
+			label = calloutLabelFromClass(element);
+		}
+
+		StringBuilder quoteContent = new StringBuilder();
+		quoteContent.append("**").append(label).append("**\n\n");
+		processElement(calloutContent, quoteContent, state);
+		appendBlockquote(quoteContent.toString(), result);
+	}
+
+	/**
+	 * Appends content with Markdown blockquote prefixes.
+	 */
+	private static void appendBlockquote(final String content, final StringBuilder result) {
+		String[] lines = content.trim().split("\n", -1);
 		for (String line : lines) {
-			result.append("> ").append(line).append("\n");
+			result.append(">");
+			if (!line.isEmpty()) {
+				result.append(" ").append(line);
+			}
+			result.append("\n");
 		}
 		result.append("\n");
+	}
+
+	/**
+	 * Processes an interactive tab heading as a linear Markdown heading.
+	 */
+	private static void processTabHeading(final Element element, final StringBuilder result) {
+		String heading = markdownVisibleText(element);
+		if (!heading.isEmpty()) {
+			ensureBlankLine(result);
+			result.append("#### ").append(heading).append("\n\n");
+		}
 	}
 
 	/**
@@ -458,7 +555,12 @@ public final class HtmlToMarkdownConverter {
 		for (Element cell : row.select("th, td")) {
 			StringBuilder cellContent = new StringBuilder();
 			processElement(cell, cellContent, state);
-			result.append(" ").append(cellContent.toString().trim().replaceAll("\\s+", " ")).append(" |");
+			String content = cellContent.toString().trim().replaceAll("\\s+", " ");
+			if (isTechnicalTableCell(cell, content)) {
+				content = normalizeTypographicQuotes(content);
+			}
+			content = escapeTablePipes(content);
+			result.append(" ").append(content).append(" |");
 			cellCount++;
 		}
 		result.append("\n");
@@ -498,18 +600,191 @@ public final class HtmlToMarkdownConverter {
 	}
 
 	/**
+	 * Replaces typographic quotes with their machine-readable ASCII equivalents in technical
+	 * content.
+	 */
+	private static String normalizeTypographicQuotes(final String value) {
+		StringBuilder normalized = new StringBuilder(value.length());
+		for (int i = 0; i < value.length(); i++) {
+			char character = value.charAt(i);
+			switch (character) {
+			case '\u2018':
+			case '\u2019':
+			case '\u201a':
+			case '\u201b':
+				normalized.append('\'');
+				break;
+			case '\u201c':
+			case '\u201d':
+			case '\u201e':
+			case '\u201f':
+				normalized.append('"');
+				break;
+			default:
+				normalized.append(character);
+				break;
+			}
+		}
+		return normalized.toString();
+	}
+
+	/**
+	 * Checks whether a table cell contains code markup or syntax that must retain ASCII quotes.
+	 */
+	private static boolean isTechnicalTableCell(final Element cell, final String content) {
+		return cell.selectFirst("code, pre, kbd, samp") != null
+				|| content.indexOf('\\') >= 0
+				|| content.matches(".*[\\p{Alnum}_.:-]+=[\\u2018\\u2019\\u201c\\u201d].*");
+	}
+
+	/**
+	 * Escapes pipe characters that would otherwise create extra Markdown table cells. An odd
+	 * number of existing backslashes is retained as an existing Markdown escape; an even number is
+	 * extended so literal backslashes and the pipe can both survive Markdown rendering.
+	 */
+	private static String escapeTablePipes(final String value) {
+		StringBuilder escaped = new StringBuilder(value.length());
+		for (int i = 0; i < value.length(); i++) {
+			char character = value.charAt(i);
+			if (character == '|') {
+				int precedingBackslashes = 0;
+				for (int j = i - 1; j >= 0 && value.charAt(j) == '\\'; j--) {
+					precedingBackslashes++;
+				}
+				if (precedingBackslashes % 2 == 0) {
+					escaped.append('\\');
+				}
+			}
+			escaped.append(character);
+		}
+		return escaped.toString();
+	}
+
+	/**
+	 * Creates the anchor slug used by common Markdown renderers for a heading.
+	 */
+	private static String markdownHeadingSlug(final String heading) {
+		String lowerCaseHeading = heading.toLowerCase(Locale.ROOT);
+		StringBuilder slug = new StringBuilder(lowerCaseHeading.length());
+		for (int i = 0; i < lowerCaseHeading.length(); i++) {
+			char character = lowerCaseHeading.charAt(i);
+			if (Character.isLetterOrDigit(character) || character == '-' || character == '_') {
+				slug.append(character);
+			} else if (Character.isWhitespace(character)) {
+				slug.append('-');
+			}
+		}
+		return slug.toString();
+	}
+
+	/**
+	 * Returns text that is visible in the Markdown export.
+	 */
+	private static String markdownVisibleText(final Element element) {
+		Element visibleContent = element.clone();
+		visibleContent.select(".visible-print-inline, .sentry-print-tab-heading, script, style, noscript").remove();
+		for (Element image : visibleContent.select("img")) {
+			image.before(new TextNode(image.attr("alt")));
+			image.remove();
+		}
+		return visibleContent.text().trim();
+	}
+
+	/**
+	 * Derives a callout title from its modifier class.
+	 */
+	private static String calloutLabelFromClass(final Element element) {
+		for (String className : element.classNames()) {
+			if (className.startsWith("callout-") && className.length() > "callout-".length()) {
+				String type = className.substring("callout-".length());
+				return type.substring(0, 1).toUpperCase(Locale.ROOT) + type.substring(1).toLowerCase(Locale.ROOT);
+			}
+		}
+		return "Note";
+	}
+
+	/**
 	 * Tracks the current state during HTML to Markdown conversion.
 	 */
 	private static class ConversionState {
 
 		private boolean inPreformatted = false;
 		private int listDepth = 0;
+		private final Map<String, String> fragmentSlugs;
 
-		ConversionState() {}
+		ConversionState(final Element root) {
+			fragmentSlugs = buildFragmentSlugs(root);
+		}
 
 		ConversionState(final ConversionState other) {
 			this.inPreformatted = other.inPreformatted;
 			this.listDepth = other.listDepth;
+			this.fragmentSlugs = other.fragmentSlugs;
+		}
+
+		private static Map<String, String> buildFragmentSlugs(final Element root) {
+			Map<String, String> slugs = new HashMap<>();
+			Set<String> usedSlugs = new HashSet<>();
+			Map<String, List<String>> slugsByHeadingText = new HashMap<>();
+
+			for (Element heading : root.select("h1, h2, h3, h4, h5, h6, uib-tab-heading")) {
+				if (heading.closest("table, .visible-print-inline, .sentry-print-tab-heading") != null) {
+					continue;
+				}
+
+				String headingText = markdownVisibleText(heading);
+				String baseSlug = markdownHeadingSlug(headingText);
+				if (baseSlug.isEmpty()) {
+					continue;
+				}
+				String headingSlug = uniqueHeadingSlug(baseSlug, usedSlugs);
+				boolean isHtmlHeading = heading.tagName().matches("h[1-6]");
+
+				if (isHtmlHeading && !heading.id().isEmpty()) {
+					slugs.put(heading.id(), headingSlug);
+				}
+				slugs.putIfAbsent(headingSlug, headingSlug);
+				slugsByHeadingText.computeIfAbsent(headingText, ignored -> new ArrayList<>()).add(headingSlug);
+
+				Element previousElement = heading.previousElementSibling();
+				if (isHtmlHeading
+						&& previousElement != null
+						&& "a".equals(previousElement.tagName())
+						&& !previousElement.id().isEmpty()
+						&& previousElement.text().isBlank()
+						&& !previousElement.hasAttr("href")) {
+					slugs.put(previousElement.id(), headingSlug);
+				}
+			}
+
+			for (Element link : root.select("a[href^=#]")) {
+				String target = link.attr("href").substring(1);
+				List<String> matchingSlugs = slugsByHeadingText.get(markdownVisibleText(link));
+				boolean isTocLink = link.closest("#toc, #right-toc, .toc, .toc-inline-container") != null;
+				if (isTocLink && !slugs.containsKey(target) && matchingSlugs != null && matchingSlugs.size() == 1) {
+					slugs.put(target, matchingSlugs.get(0));
+				}
+			}
+
+			return slugs;
+		}
+
+		private static String uniqueHeadingSlug(final String baseSlug, final Set<String> usedSlugs) {
+			String candidate = baseSlug;
+			int suffix = 1;
+			while (!usedSlugs.add(candidate)) {
+				candidate = baseSlug + "-" + suffix++;
+			}
+			return candidate;
+		}
+
+		String resolveHref(final String href) {
+			if (!href.startsWith("#")) {
+				return href;
+			}
+
+			String resolved = fragmentSlugs.get(href.substring(1));
+			return resolved == null ? href : "#" + resolved;
 		}
 
 		boolean isInPreformatted() {

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -51,6 +51,10 @@ This allows the Maven Skin and [Velocity-processed pages in a Maven Site](https:
 | `#[[$indexTool]]#` | To create search indexes | [IndexTool](apidocs/org/sentrysoftware/maven/skin/IndexTool.html) |
 | `#[[$aiIndexTool]]#` | To create AI-ready Markdown files from HTML documentation | [AIIndexTool](apidocs/org/sentrysoftware/maven/skin/AIIndexTool.html) |
 
+The AI-ready Markdown converter preserves the document's machine-readable structure. Sentry Maven Skin callouts
+remain blockquotes, interactive tabs become linear headings, table pipes and technical quotes remain literal data,
+table of contents links use the same anchors as Markdown headings, and print-only link footnotes are omitted.
+
 The above tools are designed to be used only in the Velocity template of a [Maven Site Skin](https://maven.apache.org/plugins/maven-site-plugin/examples/creatingskins.html) as in the example below:
 
 #[[

--- a/src/test/java/org/sentrysoftware/maven/skin/HtmlToMarkdownConverterTest.java
+++ b/src/test/java/org/sentrysoftware/maven/skin/HtmlToMarkdownConverterTest.java
@@ -224,6 +224,13 @@ class HtmlToMarkdownConverterTest {
 				HtmlToMarkdownConverter
 						.convert(
 								"<div class='callout callout-caution'><p>Caution content.</p></div>"));
+
+		String nestedCallout = "<div class='callout callout-warning'><p>Outer content.</p>" +
+				"<div class='callout callout-tip'><div class='callout-title'>Tip</div>" +
+				"<p>Inner content.</p></div></div>";
+		String nestedResult = HtmlToMarkdownConverter.convert(nestedCallout);
+		assertTrue(nestedResult.startsWith("> **Warning**"));
+		assertTrue(nestedResult.contains("> > **Tip**"));
 	}
 
 	@Test
@@ -373,6 +380,10 @@ class HtmlToMarkdownConverterTest {
 				"<table><tr><th>Example</th></tr>" +
 				"<tr><td>key=\u201cvalue\u201d</td></tr>" +
 				"<tr><td>Equation x = \u201cunknown\u201d.</td></tr></table>" +
+				"<table><tr><th>Mixed content</th></tr>" +
+				"<tr><td>Use <code>foo</code>, called \u201cbar\u201d.</td></tr>" +
+				"<tr><td>Path \\server, called \u201cbaz\u201d.</td></tr>" +
+				"<tr><td>Use key=\u201cvalue\u201d, called \u201cqux\u201d.</td></tr></table>" +
 				"<p><code>key=\u201cvalue\u201d</code></p>" +
 				"<pre><code>key=\u201cvalue\u201d</code></pre>";
 
@@ -382,6 +393,9 @@ class HtmlToMarkdownConverterTest {
 		assertTrue(result.contains("She said \u201chello\u201d."));
 		assertTrue(result.contains("| key=\"value\" |"));
 		assertTrue(result.contains("Equation x = \u201cunknown\u201d."));
+		assertTrue(result.contains("Use `foo`, called \u201cbar\u201d."));
+		assertTrue(result.contains("Path \\server, called \u201cbaz\u201d."));
+		assertTrue(result.contains("Use key=\"value\", called \u201cqux\u201d."));
 		assertTrue(result.contains("`key=\"value\"`"));
 		assertTrue(result.contains("```\nkey=\"value\"\n```"));
 	}

--- a/src/test/java/org/sentrysoftware/maven/skin/HtmlToMarkdownConverterTest.java
+++ b/src/test/java/org/sentrysoftware/maven/skin/HtmlToMarkdownConverterTest.java
@@ -21,6 +21,7 @@ package org.sentrysoftware.maven.skin;
  */
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jsoup.nodes.Element;
@@ -196,5 +197,210 @@ class HtmlToMarkdownConverterTest {
 		assertTrue(result.contains("*italic*"));
 		assertTrue(result.contains("- Item 1"));
 		assertTrue(result.contains("[this link](http://example.com)"));
+	}
+
+	@Test
+	void testIssue115AllCalloutTypesUseBalancedMarkdown() {
+		String[] labels = { "Note", "Tip", "Important", "Warning", "Caution" };
+
+		for (String label : labels) {
+			String html = "<div class='callout callout-" + label.toLowerCase() + "'>" +
+					"<div class='callout-title'><i class='fa-solid fa-icon'></i> " + label + "</div>" +
+					"<p><code>expectedResult</code> only needs to match one line.</p></div>";
+
+			assertEquals(
+					"> **" + label + "**\n>\n> `expectedResult` only needs to match one line.",
+					HtmlToMarkdownConverter.convert(html));
+		}
+
+		assertEquals(
+				"> **Warning**\n>\n> Warning content.",
+				HtmlToMarkdownConverter
+						.convert(
+								"<div class='callout callout-warning'><div class='callout-title'>" +
+										"<i class='fa-solid fa-icon'></i></div><p>Warning content.</p></div>"));
+		assertEquals(
+				"> **Caution**\n>\n> Caution content.",
+				HtmlToMarkdownConverter
+						.convert(
+								"<div class='callout callout-caution'><p>Caution content.</p></div>"));
+	}
+
+	@Test
+	void testIssue115EmptyInlineIconsDoNotEmitMarkdownDelimiters() {
+		String html = "<p>Before <i class='fa-solid fa-triangle-exclamation'></i> after</p>";
+
+		assertEquals("Before after", HtmlToMarkdownConverter.convert(html));
+		assertEquals("Before after", HtmlToMarkdownConverter.convert("<p>Before<i> </i>after</p>"));
+	}
+
+	@Test
+	void testIssue116TabsUseOneCleanHeading() {
+		String html = "<uib-tabset><uib-tab>" +
+				"<uib-tab-heading><span class='fa-solid fa-table-list'></span> Input</uib-tab-heading>" +
+				"<p class='sentry-print-tab-heading'><strong>" +
+				"<span class='fa-solid fa-table-list'></span> Input</strong></p>" +
+				"<table><tr><th>col</th></tr><tr><td>value</td></tr></table>" +
+				"</uib-tab></uib-tabset>";
+
+		assertEquals(
+				"#### Input\n\n| col |\n| --- |\n| value |",
+				HtmlToMarkdownConverter.convert(html));
+	}
+
+	@Test
+	void testIssue117TocLinksUseMarkdownHeadingSlugs() {
+		String longHeading = "Step 2 - Create the connector directory and YAML file";
+		String html = "<ul id='toc'>" +
+				"<li><a href='#ordering-strategy-28cheap-to-expensive-29'>" +
+				"Ordering strategy (cheap to expensive)" +
+				"<sup class='visible-print-inline'>[7]</sup></a></li>" +
+				"<li><a href='#multiinstance-3a-one-run-for-all-instances'>" +
+				"MultiInstance: one run for all instances</a></li>" +
+				"<li><a href='#a1-prepare-it-resources-structure'>1. Prepare IT resources structure</a></li>" +
+				"<li><a href='#step-2---create-the-connector-directory-and-yaml-file'>" + longHeading + "</a></li>" +
+				"<li><a href='#hw-e2-80-94-hardware'>HW \u2014 Hardware</a></li>" +
+				"</ul>" +
+				"<a id='ordering-strategy-28cheap-to-expensive-29'></a>" +
+				"<h2 id='ordering-strategy-cheap-to-expensive'>" +
+				"<a href='#ordering-strategy-cheap-to-expensive'>Ordering strategy (cheap to expensive)</a></h2>" +
+				"<h2 id='multiinstance-one-run-for-all-instances'>" +
+				"<a href='#multiinstance-one-run-for-all-instances'>" +
+				"MultiInstance: one run for all instances</a></h2>" +
+				"<h2 id='a1-prepare-it-resources-structure'>" +
+				"<a href='#a1-prepare-it-resources-structure'>1. Prepare IT resources structure</a></h2>" +
+				"<h2 id='step-2---create-the-connector-directory-and-yaml-f'>" +
+				"<a href='#step-2---create-the-connector-directory-and-yaml-f'>" + longHeading + "</a></h2>" +
+				"<h2 id='hw--hardware'><a href='#hw--hardware'>HW \u2014 Hardware</a></h2>";
+
+		String result = HtmlToMarkdownConverter.convert(html);
+
+		assertTrue(result.contains("[Ordering strategy (cheap to expensive)](#ordering-strategy-cheap-to-expensive)"));
+		assertTrue(
+				result
+						.contains(
+								"[MultiInstance: one run for all instances](#multiinstance-one-run-for-all-instances)"));
+		assertTrue(result.contains("[1. Prepare IT resources structure](#1-prepare-it-resources-structure)"));
+		assertTrue(result.contains("[" + longHeading + "](#step-2---create-the-connector-directory-and-yaml-file)"));
+		assertTrue(result.contains("[HW \u2014 Hardware](#hw--hardware)"));
+		assertTrue(result.contains("## Ordering strategy (cheap to expensive)"));
+		assertFalse(result.contains("#ordering-strategy-28cheap-to-expensive-29"));
+		assertFalse(result.contains("[7]"));
+		assertFalse(result.contains("#multiinstance-3a-one-run-for-all-instances"));
+		assertFalse(result.contains("#a1-prepare-it-resources-structure"));
+		assertFalse(result.contains("#step-2---create-the-connector-directory-and-yaml-f)"));
+	}
+
+	@Test
+	void testIssue117DuplicateHeadingSlugsUseMarkdownSuffixes() {
+		String html = "<ul id='toc'><li><a href='#syntax'>Syntax</a></li>" +
+				"<li><a href='#syntax-1'>Syntax</a></li></ul>" +
+				"<h3 id='syntax'><a href='#syntax'>Syntax</a></h3>" +
+				"<a id='syntax-1'></a><h3 id='syntax_2'><a href='#syntax_2'>Syntax</a></h3>";
+
+		String result = HtmlToMarkdownConverter.convert(html);
+
+		assertTrue(result.contains("[Syntax](#syntax)"));
+		assertTrue(result.contains("[Syntax](#syntax-1)"));
+		assertFalse(result.contains("#syntax_2"));
+	}
+
+	@Test
+	void testIssue117SlugMapMatchesOnlyRenderedHeadings() {
+		String html = "<ul id='toc'>" +
+				"<li><a href='#overview-heading'>Overview</a></li>" +
+				"<li><a href='#title-heading'>Title</a></li>" +
+				"<li><a href='#syntax-literal'>Syntax-1</a></li></ul>" +
+				"<uib-tab-heading>Overview</uib-tab-heading>" +
+				"<h2 id='overview-heading'><a href='#overview-heading'>Overview" +
+				"<sup class='visible-print-inline'>[9]</sup></a></h2>" +
+				"<table><tr><td><h2>Title</h2></td></tr></table>" +
+				"<h2 id='title-heading'>Title</h2>" +
+				"<h2>Syntax</h2><h2>Syntax</h2>" +
+				"<h2 id='syntax-literal'>Syntax-1</h2>";
+
+		String result = HtmlToMarkdownConverter.convert(html);
+
+		assertTrue(result.contains("[Overview](#overview-1)"));
+		assertTrue(result.contains("[Title](#title)"));
+		assertTrue(result.contains("[Syntax-1](#syntax-1-1)"));
+		assertFalse(result.contains("#overview-9"));
+	}
+
+	@Test
+	void testIssue117TextFallbackDoesNotRewriteOrdinaryLinks() {
+		String html = "<p><a href='#custom-anchor'>Overview</a></p>" +
+				"<div id='custom-anchor'>Custom target</div><h2 id='overview'>Overview</h2>";
+
+		String result = HtmlToMarkdownConverter.convert(html);
+
+		assertTrue(result.contains("[Overview](#custom-anchor)"));
+		assertFalse(result.contains("[Overview](#overview)"));
+	}
+
+	@Test
+	void testIssue117HeadingCrossReferenceIsNotMistakenForSelfLink() {
+		String html = "<h2 id='current'><a href='#other'>See the other section</a></h2>" +
+				"<h2 id='other'>Other section</h2>";
+
+		String result = HtmlToMarkdownConverter.convert(html);
+
+		assertTrue(result.contains("## [See the other section](#other-section)"));
+	}
+
+	@Test
+	void testIssue118TablePreservesEntityAndBackslashEscapedPipes() {
+		String html = "<table><tr><th>Entity</th><th>Backslash</th></tr>" +
+				"<tr><td>Model&#124;Size</td><td>2\\|11</td></tr>" +
+				"<tr><td>ST4000NM&#124;4000</td><td>value</td></tr></table>";
+
+		String result = HtmlToMarkdownConverter.convert(html);
+
+		assertEquals(
+				"| Entity | Backslash |\n" +
+						"| --- | --- |\n" +
+						"| Model\\|Size | 2\\|11 |\n" +
+						"| ST4000NM\\|4000 | value |",
+				result);
+	}
+
+	@Test
+	void testIssue119TableRestoresStraightQuotesInTechnicalContent() {
+		String html = "<table><tr><th>Path</th></tr><tr>" +
+				"<td>\\\\SRV01\\root\\cimv2:Win32_Account.Domain=\u201cCONTOSO\u201d," +
+				"Name=\u201cjsmith\u201d</td></tr>" +
+				"<tr><td>She said \u201chello\u201d.</td></tr></table>" +
+				"<table><tr><th>Example</th></tr>" +
+				"<tr><td>key=\u201cvalue\u201d</td></tr>" +
+				"<tr><td>Equation x = \u201cunknown\u201d.</td></tr></table>" +
+				"<p><code>key=\u201cvalue\u201d</code></p>" +
+				"<pre><code>key=\u201cvalue\u201d</code></pre>";
+
+		String result = HtmlToMarkdownConverter.convert(html);
+
+		assertTrue(result.contains("Domain=\"CONTOSO\",Name=\"jsmith\""));
+		assertTrue(result.contains("She said \u201chello\u201d."));
+		assertTrue(result.contains("| key=\"value\" |"));
+		assertTrue(result.contains("Equation x = \u201cunknown\u201d."));
+		assertTrue(result.contains("`key=\"value\"`"));
+		assertTrue(result.contains("```\nkey=\"value\"\n```"));
+	}
+
+	@Test
+	void testIssue120PrintOnlyLinkFootnotesAreIgnored() {
+		String html = "<p><a href='run-and-debug.html'>Run and Debug Locally</a>" +
+				"<sup class='visible-print-inline'>[1]</sup></p>" +
+				"<ul><li><a href='https://example.com/WBEMGenLUN.yaml'>WBEMGenLUN</a>" +
+				"<sup class='visible-print-inline'>[1]</sup></li>" +
+				"<li><a href='https://example.com/IpmiTool.yaml'>IpmiTool</a>" +
+				"<sup class='visible-print-inline'>[2]</sup></li></ul>";
+
+		String result = HtmlToMarkdownConverter.convert(html);
+
+		assertTrue(result.contains("[Run and Debug Locally](run-and-debug.html)"));
+		assertTrue(result.contains("[WBEMGenLUN](https://example.com/WBEMGenLUN.yaml)"));
+		assertTrue(result.contains("[IpmiTool](https://example.com/IpmiTool.yaml)"));
+		assertFalse(result.contains("[1]"));
+		assertFalse(result.contains("[2]"));
 	}
 }


### PR DESCRIPTION
## Summary

- Preserve callouts as titled blockquotes and linearize interactive tabs
- Align table-of-contents links with generated Markdown heading anchors
- Preserve table pipes and normalize quotes in technical content
- Omit print-only link footnotes and document the export behavior
- Add regression coverage for issues 115–120

## Testing

- Unit tests added for callouts, tabs, heading slugs, tables, quotes, and print-only content